### PR TITLE
feat(lambda-edge): add bootstrap Lambda edge

### DIFF
--- a/templates/lambda-edge/.gitignore
+++ b/templates/lambda-edge/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+lambda.zip
+.yarn

--- a/templates/lambda-edge/README.md
+++ b/templates/lambda-edge/README.md
@@ -1,0 +1,4 @@
+```
+npm install
+npm run deploy
+```

--- a/templates/lambda-edge/package.json
+++ b/templates/lambda-edge/package.json
@@ -3,8 +3,9 @@
   "scripts": {
     "build": "esbuild --bundle --outfile=./dist/index.js --platform=node --target=node18 ./src/index.ts",
     "zip": "zip -j lambda.zip dist/index.js",
-    "update": "aws lambda update-function-code --zip-file fileb://lambda.zip --function-name hello",
-    "deploy": "run-s build zip update"
+    "update": "aws lambda update-function-code --zip-file fileb://lambda.zip --function-name hello --region us-east-1",
+    "publish": "aws lambda publish-version --function-name hello --region us-east-1",
+    "deploy": "run-s build zip update publish"
   },
   "devDependencies": {
     "esbuild": "^0.17.11",

--- a/templates/lambda-edge/package.json
+++ b/templates/lambda-edge/package.json
@@ -1,0 +1,16 @@
+{
+  "type": "module",
+  "scripts": {
+    "build": "esbuild --bundle --outfile=./dist/index.js --platform=node --target=node18 ./src/index.ts",
+    "zip": "zip -j lambda.zip dist/index.js",
+    "update": "aws lambda update-function-code --zip-file fileb://lambda.zip --function-name hello",
+    "deploy": "run-s build zip update"
+  },
+  "devDependencies": {
+    "esbuild": "^0.17.11",
+    "npm-run-all": "^4.1.5"
+  },
+  "dependencies": {
+    "hono": "^3.2.7"
+  }
+}

--- a/templates/lambda-edge/src/index.ts
+++ b/templates/lambda-edge/src/index.ts
@@ -1,0 +1,8 @@
+import { Hono } from 'hono'
+import { handle } from 'hono/aws-lambda'
+
+const app = new Hono()
+
+app.get('/', (c) => c.text('Hello Hono!'))
+
+export const handler = handle(app)

--- a/templates/lambda-edge/src/index.ts
+++ b/templates/lambda-edge/src/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { handle } from 'hono/aws-lambda'
+import { handle } from 'hono/lambda-edge'
 
 const app = new Hono()
 


### PR DESCRIPTION
Here are the specific changes needed in the package.json file:

1. In the update script, add the --region us-east-1 option. This is necessary because Lambda@Edge functions must typically be deployed in the us-east-1 region.
- https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-the-edge.html

2. Add a new script called publish that uses aws lambda publish-version to create a new version of the Lambda function. Lambda@Edge requires you to deploy a specific version or an alias, so we need this step
- https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-edit-function.html