### PR TITLE
Patch fastly deploy command

### DIFF
--- a/templates/fastly/package.json
+++ b/templates/fastly/package.json
@@ -3,7 +3,7 @@
     "dev": "fastly compute serve --watch",
     "prebuild": "node ./build.js",
     "build": "js-compute-runtime bin/index.js bin/main.wasm",
-    "deploy": "yarn build && fastly compute publish"
+    "deploy": "fastly compute publish"
   },
   "devDependencies": {
     "esbuild": "^0.17.12"

--- a/templates/fastly/package.json
+++ b/templates/fastly/package.json
@@ -3,7 +3,7 @@
     "dev": "fastly compute serve --watch",
     "prebuild": "node ./build.js",
     "build": "js-compute-runtime bin/index.js bin/main.wasm",
-    "deploy": "yarn build && fastly compute deploy"
+    "deploy": "yarn build && fastly compute publish"
   },
   "devDependencies": {
     "esbuild": "^0.17.12"


### PR DESCRIPTION
Fastly deploy commnad  need a package tar.gz.
But yarn build make only bin folder and wasm/js files. 
So I change the command from "deploy" to "publish".
"publish" command is " Build and deploy a Compute@Edge package to a Fastly service".