### PR TITLE
fix(templates/bun): remove `jsxFragmentFactory` from tsconfig.json

### DIFF
--- a/templates/bun/tsconfig.json
+++ b/templates/bun/tsconfig.json
@@ -3,7 +3,6 @@
     "esModuleInterop": true,
     "strict": true,
     "jsx": "react-jsx",
-    "jsxFragmentFactory": "Fragment",
     "jsxImportSource": "hono/jsx"
   }
 }


### PR DESCRIPTION
The default `tsconfig.json` gives an error.

![image](https://github.com/honojs/starter/assets/3425302/27fdb04e-f376-402f-8848-73d273971088)

I tried adding a `jsxFactory` as the message suggest.

![image](https://github.com/honojs/starter/assets/3425302/23d05ea1-5268-4a5c-9131-0d9c56360414)

I conclude that `"jsx": "react-jsx"` already does the job for `jsxFactory` and `jsxFragmentFactory`. So I propose this change to remove it completely. Thank you.