### PR TITLE
Add bun typings to templates/bun/tsconfig.json

### DIFF
--- a/templates/bun/tsconfig.json
+++ b/templates/bun/tsconfig.json
@@ -3,6 +3,7 @@
     "esModuleInterop": true,
     "strict": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "hono/jsx"
+    "jsxImportSource": "hono/jsx",
+    "types": ["bun-types"]
   }
 }


### PR DESCRIPTION
Using Bun 1.0.2, `bun:*` import types seemed to be broken using the Bun preset.

Recreate:

`bun create hono@latest project-name`
Import any `bun` package in `src/index.ts` - `Cannot find module (x) or its corresponding type declarations.`

Quick check at [bun-types](https://github.com/oven-sh/bun-types), possibly missing `"types": ["bun-types"]` from `tsconfig.json`

Change attached, cheers