### PR TITLE
JavaScript starter (with type checking) for NodeJS

### DIFF
--- a/templates/javascript/nodejs/README.md
+++ b/templates/javascript/nodejs/README.md
@@ -1,0 +1,19 @@
+```
+npm install
+npm run start
+```
+
+```
+open http://localhost:3000
+```
+
+Notes:
+
+- This project adds TypeScript and the type definitions for Node.js as a 
+"devDependency", to enable automatic type checking (at least in VSCode) for the 
+JavaScript source files.
+
+- Type checking is configured via `jsconfig.json`.
+
+- To check (and not emit) the JavaScript source files directly with the 
+TypeScript compiler, use: `tsc --noEmit --project jsconfig.json`

--- a/templates/javascript/nodejs/jsconfig.json
+++ b/templates/javascript/nodejs/jsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "experimentalDecorators": true,
+    "types": ["@types/node"],
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "paths": {}
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.js"]
+}

--- a/templates/javascript/nodejs/package.json
+++ b/templates/javascript/nodejs/package.json
@@ -1,0 +1,14 @@
+{
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.1.0",
+    "hono": "^3.7.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "@types/node": "^20.6.0"
+  }
+}

--- a/templates/javascript/nodejs/src/index.js
+++ b/templates/javascript/nodejs/src/index.js
@@ -1,0 +1,7 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+
+const app = new Hono()
+app.get('/', (c) => c.text('Hello Hono!'))
+
+serve(app)


### PR DESCRIPTION
I'm proposing the addition of a JavaScript starter for your consideration.

Sometimes our project requirements specify the use of JavaScript (with optional types declared in JSDoc comments) instead of TypeScript.

The proposed starter sets up the current standard Hono starter, but in JavaScript, in a project environment that still enables type checking.

Please see the included README's "Notes" section for more information about the starter project.

Please let me know if you think this is too opinionated. 

If you approve the request, or simply find it useful, I can easily add another JavaScript starter for Bun.