### PR TITLE
feat: add endpts starter template for Hono

### DIFF
--- a/templates/endpts/.gitignore
+++ b/templates/endpts/.gitignore
@@ -1,0 +1,33 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Dependency directories
+node_modules/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
+
+# macOS
+.DS_Store
+
+# endpts
+.ep
+.endpts

--- a/templates/endpts/README.md
+++ b/templates/endpts/README.md
@@ -1,0 +1,20 @@
+# endpts starter
+
+## Local development
+
+```shell
+npm install
+npm run dev
+```
+
+The endpts dev server will automatically watch for changes and hot reload your Hono app.
+
+```shell
+curl http://localhost:3000
+```
+
+The `routes/` directory contains all the routes for your application. endpts will automatically scan this directory and register the routes.
+
+## Deploying your Hono app to endpts
+
+Deploy your Hono app via the [endpts Dashboard](https://dashboard.endpts.io).

--- a/templates/endpts/package.json
+++ b/templates/endpts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "endpts",
+  "type": "module",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "endpts dev"
+  },
+  "devDependencies": {
+    "@endpts/devtools": "^1.2.0",
+    "@endpts/types": "^1.1.0",
+    "@types/node": "^20.8.0",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "hono": "^3.7.3"
+  }
+}

--- a/templates/endpts/routes/index.ts
+++ b/templates/endpts/routes/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/", (c) => c.text("Hello Hono!"));
+
+export default {
+  handler: app.fetch,
+};

--- a/templates/endpts/tsconfig.json
+++ b/templates/endpts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Adds a Hono starter template to enable developers deploy their Hono apps to [endpts Serverless Functions](https://endpts.io/)