### PR TITLE
migrate from npm-run-all to npm-run-all2

### DIFF
--- a/templates/aws-lambda/package.json
+++ b/templates/aws-lambda/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "esbuild": "^0.17.11",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all2": "^6.1.1"
   },
   "dependencies": {
     "hono": "^3.11.12"

--- a/templates/lambda-edge/package.json
+++ b/templates/lambda-edge/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "esbuild": "^0.17.11",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all2": "^6.1.1"
   },
   "dependencies": {
     "hono": "^3.11.12"


### PR DESCRIPTION
[npm-run-all](https://github.com/mysticatea/npm-run-all) has not been maintained for 5 years and has some bugs.

- Signals are not handled correctly: https://github.com/mysticatea/npm-run-all/pull/171 was merged but not released
- Dependents are left out of date and reported having vulnerabilty: https://github.com/mysticatea/npm-run-all/issues/257

[npm-run-all2](https://github.com/bcomnes/npm-run-all2) is a simple fork of npm-run-all and addressed these issues.