### PR TITLE
Fastly should be external in esbuild.

### DIFF
--- a/templates/fastly/build.js
+++ b/templates/fastly/build.js
@@ -6,6 +6,7 @@ build({
   minify: true,
   outfile: 'bin/index.js',
   platform: 'node',
+  external: ['fastly:*']
 }).catch((error) => {
   console.error(error)
   process.exit(1)


### PR DESCRIPTION
Having fastly external allows you to import fastly modules as per the fastly documentation and gives you access to fastly:experimental.