### PR TITLE
Fix build command in fastly.toml

### DIFF
--- a/templates/fastly/fastly.toml
+++ b/templates/fastly/fastly.toml
@@ -9,4 +9,5 @@ manifest_version = 2
 service_id = ""
 
 [scripts]
-  build = "node ./build.js && js-compute-runtime bin/index.js bin/main.wasm"
+build = "npm run build"
+post_init = "npm install"


### PR DESCRIPTION
After `npm create hono@latest` with picking fastly template, currently `fastly compute build` doesn't work (probably it's outdated). We can find the right build commands at https://github.com/fastly/compute-starter-kit-javascript-empty/blob/main/fastly.toml#L11-L12.