### PR TITLE
add @hono/vite-dev-server in package.json

### DIFF
--- a/templates/x-basic/package.json
+++ b/templates/x-basic/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240403.0",
     "@hono/vite-cloudflare-pages": "^0.2.4",
+    "@hono/vite-dev-server": "^0.10.0",
     "vite": "^5.0.12",
     "wrangler": "^3.47.0"
   }


### PR DESCRIPTION
when I create x-basic template and using pnpm,
cloudflare adapater from vite-dev-server in vite.config.ts is missing.

```ts
import adapter from "@hono/vite-dev-server/cloudflare";
```

it's fixed via installing vite-dev-server explicitly in package.json.
for avoiding same error, update template are welcome.