### PR TITLE
chore: use farmup replace tsx

### DIFF
--- a/templates/nodejs/.gitignore
+++ b/templates/nodejs/.gitignore
@@ -26,3 +26,6 @@ lerna-debug.log*
 
 # misc
 .DS_Store
+
+# build
+dist

--- a/templates/nodejs/package.json
+++ b/templates/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "tsx watch src/index.ts"
+    "dev": "farmup --watch src/index.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.11.1",
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.17",
-    "tsx": "^4.7.1"
+    "farmup": "^0.0.8"
   }
 }

--- a/templates/nodejs/src/index.ts
+++ b/templates/nodejs/src/index.ts
@@ -4,10 +4,10 @@ import { Hono } from 'hono'
 const app = new Hono()
 
 app.get('/', (c) => {
-  return c.text('Hello Hono!')
+  return c.text('Hello Hono2!')
 })
 
-const port = 3000
+const port = 3002
 console.log(`Server is running on port ${port}`)
 
 serve({

--- a/templates/nodejs/src/index.ts
+++ b/templates/nodejs/src/index.ts
@@ -4,10 +4,10 @@ import { Hono } from 'hono'
 const app = new Hono()
 
 app.get('/', (c) => {
-  return c.text('Hello Hono2!')
+  return c.text('Hello Hono!')
 })
 
-const port = 3002
+const port = 3000
 console.log(`Server is running on port ${port}`)
 
 serve({


### PR DESCRIPTION
Farmup is based on farm (compiled by rust) to update nodejs applications in milliseconds. Would you like to replace tsx with farmup?

https://www.farmfe.org/

![image](https://github.com/honojs/starter/assets/66500121/35724574-581d-46e4-827c-698430d984d7)
