### PR TITLE
Point to @cloudflare/workers-types/2023-07-01 from tsconfig.json

### DIFF
--- a/templates/cloudflare-pages/tsconfig.json
+++ b/templates/cloudflare-pages/tsconfig.json
@@ -9,7 +9,7 @@
       "ESNext"
     ],
     "types": [
-      "@cloudflare/workers-types",
+      "@cloudflare/workers-types/2023-07-01",
       "vite/client"
     ],
     "jsx": "react-jsx",

--- a/templates/cloudflare-workers/tsconfig.json
+++ b/templates/cloudflare-workers/tsconfig.json
@@ -9,7 +9,7 @@
       "ESNext"
     ],
     "types": [
-      "@cloudflare/workers-types"
+      "@cloudflare/workers-types/2023-07-01"
     ],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"

--- a/templates/x-basic/tsconfig.json
+++ b/templates/x-basic/tsconfig.json
@@ -11,7 +11,7 @@
     ],
     "types": [
       "vite/client",
-      "@cloudflare/workers-types"
+      "@cloudflare/workers-types/2023-07-01"
     ],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"


### PR DESCRIPTION
I believe this change is necessary to get up-to-date TypeScript types for Cloudflare Workers.

From https://www.npmjs.com/package/@cloudflare/workers-types

> - @cloudflare/workers-types
>   The default entrypoint exposes the runtime types for a compatibility date **before** 2021-11-03.
...
> - @cloudflare/workers-types/2023-07-01
>   This entrypoint exposes the runtime types for a compatibility date **after** 2023-07-01.

I found this when I tried to use the `include` [R2ListOptions](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2listoptions) and got this TypeScript error:

> Object literal may only specify known properties, and 'include' does not exist in type 'R2ListOptions'.

![Screenshot 2024-08-08 at 16 29 10](https://github.com/user-attachments/assets/08803afa-08ab-433b-bf0a-a30e36ec4386)

To reproduce the error you can clone https://github.com/jldec/hono-latest-aug-7
There is a `fix-workers-types` branch / PR in that repo with the same fix as this PR.