### PR TITLE
Fix: Adjust configuration for Workers Builds compatibility in hono template

### DIFF
--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "wrangler dev src/index.ts",
-    "deploy": "wrangler deploy --minify src/index.ts"
+    "deploy": "wrangler deploy --minify"
   },
   "dependencies": {
     "hono": "^4.6.3"

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "wrangler dev src/index.ts",
+    "dev": "wrangler dev",
     "deploy": "wrangler deploy --minify"
   },
   "dependencies": {

--- a/templates/cloudflare-workers/wrangler.toml
+++ b/templates/cloudflare-workers/wrangler.toml
@@ -1,4 +1,5 @@
 name = "%%PROJECT_NAME%%"
+main = "src/index.ts"
 compatibility_date = "2024-04-01"
 compatibility_flags = [ "nodejs_compat" ]
 


### PR DESCRIPTION
I encountered an issue while trying out Workers Builds with the template created by `npm create hono@latest my-app`, following the instructions in the [Hono documentation for Cloudflare Workers](https://hono.dev/docs/getting-started/cloudflare-workers). The current setup seems incompatible with Workers Builds, preventing the deployment process from functioning as expected.

This PR proposes the following changes to address the issue and ensure better compatibility with Workers Builds:

- **Add `main = "src/index.ts"` to `wrangler.toml`**: This ensures that the correct entry point is specified for the Worker script.
- **Update the deploy command in `package.json` to `"deploy": "wrangler deploy --minify"`**: This simplifies the deployment process by adding the `--minify` flag, which is recommended for Workers Builds.

These changes aim to improve the deployment workflow for users working with Workers Builds, ensuring that the template functions as expected out-of-the-box.
