### PR TITLE
Enable observability for Cloudflare Worker logs

### DIFF
--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -7,7 +7,7 @@
     "hono": "^4.6.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240529.0",
-    "wrangler": "^3.57.2"
+    "@cloudflare/workers-types": "^4.20240925.0",
+    "wrangler": "^3.79.0"
   }
 }

--- a/templates/cloudflare-workers/wrangler.toml
+++ b/templates/cloudflare-workers/wrangler.toml
@@ -21,3 +21,7 @@ compatibility_flags = [ "nodejs_compat" ]
 
 # [ai]
 # binding = "AI"
+
+# [observability]
+# enabled = true
+# head_sampling_rate = 1


### PR DESCRIPTION
- Set observability.enabled to true
- Set head_sampling_rate to 1

Source: https://developers.cloudflare.com/workers/observability/logs/workers-logs/