### PR TITLE
chore: update configs for modern node

### DIFF
--- a/templates/nodejs/package.json
+++ b/templates/nodejs/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts"
   },

--- a/templates/nodejs/tsconfig.json
+++ b/templates/nodejs/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
     "strict": true,
+    "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "types": [
       "node"


### PR DESCRIPTION
This PR will slightly update the package.json and the tsconfig.json to guide users into the right direction when scaffolding their Hono project with Node.js to align with Web standards as much as possible. The recommendation is taken from the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html#im-compiling-and-running-the-outputs-in-nodejs).

The change in the package.json make sure that Node.js will interpret the package as an ES Module. The changes in the tsconfig.json accomplish several things:
- Reflect the Node.js lookup rules to determine whether a project follows ESM or CJS rules. Since we set `"type": "module"` in the package.json, the scaffolded project will follow the standardized ESM rules (plus `node_modules` support ofc). This will align Node.js and the TypeScript compiler and guide the user in the right direction.
- Force the user to author correct import statements. Since we are in ESM mode, only `import` syntax is allowed. `require` calls will error correctly already in the tsc compile step.

Combined these minor changes will make sure that the TypeScript compiler (and their IDE) guides the user in the right direction and prevent surprises when building for production. Since the chosen settings work for the strictest mode (deploying after tsc compiling directly with Node.js), they will also allow for any other deployment option later on, e.g. bundling with esbuild before deploying or using tsx directly.