### PR TITLE
chore(nodejs): display the server url

### DIFF
--- a/templates/nodejs/src/index.ts
+++ b/templates/nodejs/src/index.ts
@@ -8,7 +8,7 @@ app.get('/', (c) => {
 })
 
 const port = 3000
-console.log(`Server is running on port ${port}`)
+console.log(`Server is running on http://localhost:${port}`)
 
 serve({
   fetch: app.fetch,


### PR DESCRIPTION
On many consoles, we can access the server with `ctrl + click` at URL.
Therefore, it is useful to have server info provided in the form of URL.

![image](https://github.com/user-attachments/assets/2e8c31cb-85d8-410d-aa71-e701846005db)
