### PR TITLE
Remove redundant `deno.enable` VS Code setting

### DIFF
--- a/templates/deno/.vscode/settings.json
+++ b/templates/deno/.vscode/settings.json
@@ -2,6 +2,5 @@
   "deno.enablePaths": [
     "./"
   ],
-  "deno.enable": true,
   "editor.inlayHints.enabled": "off"
 }

--- a/templates/netlify/.vscode/settings.json
+++ b/templates/netlify/.vscode/settings.json
@@ -2,6 +2,5 @@
   "deno.enablePaths": [
     "./"
   ],
-  "deno.enable": true,
   "editor.inlayHints.enabled": "off"
 }


### PR DESCRIPTION
When a value is set for `deno.enablePaths`, the value of `deno.enable` is ignored.