### PR TITLE
feat: add GitHub Actions for "Sync versioned branch"

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -1,0 +1,45 @@
+name: Sync versioned branch
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync_branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Get create-hono version
+        id: get_version
+        run: |
+          VERSION=$(npm show create-hono version)
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d '.' -f 1,2)
+          echo "Detected version: $VERSION"
+          echo "Branch name: v$MAJOR_MINOR"
+          echo "branch_name=v$MAJOR_MINOR" >> "$GITHUB_ENV"
+
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync branch
+        run: |
+          git fetch origin
+          git switch ${{ env.branch_name }} || git switch -c ${{ env.branch_name }}
+          git reset --hard origin/main
+          git push origin ${{ env.branch_name }} --force


### PR DESCRIPTION
This PR added a GitHub Actions script. The GitHub Actions script creates a branch synchronized with the version number of the `create-hono` package. If `create-hono` refers to the latest branch and retrieves the template, it will prevent breaking changes from being introduced by the combination of `create-hono` and the template.