### PR TITLE
fix(nodejs): move console.log inside callback

### DIFF
--- a/templates/nodejs/src/index.ts
+++ b/templates/nodejs/src/index.ts
@@ -7,10 +7,9 @@ app.get('/', (c) => {
   return c.text('Hello Hono!')
 })
 
-const port = 3000
-console.log(`Server is running on http://localhost:${port}`)
-
 serve({
   fetch: app.fetch,
-  port
+  port: 3000
+}, (info) => {
+  console.log(`Server is running on http://${info.address}:${info.port}`)
 })


### PR DESCRIPTION
Changes:
- define port inline for the serve command
- moved console.log into the second argument callback of `serve`
- utilise `info.address` and `info.port` to construct the URL