### PR TITLE
feat: add `cloudflare-workers+vite` template

### DIFF
--- a/templates/cloudflare-workers+vite/.gitignore
+++ b/templates/cloudflare-workers+vite/.gitignore
@@ -1,0 +1,33 @@
+# prod
+dist/
+
+# dev
+.yarn/
+!.yarn/releases
+.vscode/*
+!.vscode/launch.json
+!.vscode/*.code-snippets
+.idea/workspace.xml
+.idea/usage.statistics.xml
+.idea/shelf
+
+# deps
+node_modules/
+.wrangler
+
+# env
+.env
+.env.production
+.dev.vars
+
+# logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# misc
+.DS_Store

--- a/templates/cloudflare-workers+vite/README.md
+++ b/templates/cloudflare-workers+vite/README.md
@@ -1,0 +1,8 @@
+```txt
+npm install
+npm run dev
+```
+
+```txt
+npm run deploy
+```

--- a/templates/cloudflare-workers+vite/package.json
+++ b/templates/cloudflare-workers+vite/package.json
@@ -2,18 +2,17 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "wrangler pages dev",
-    "deploy": "$npm_execpath run build && wrangler pages deploy"
+    "preview": "wrangler dev",
+    "deploy": "wrangler deploy"
   },
   "dependencies": {
     "hono": "^4.7.5"
   },
   "devDependencies": {
+    "@cloudflare/vite-plugin": "^0.1.15",
     "@cloudflare/workers-types": "^4.20250214.0",
-    "@hono/vite-build": "^1.2.0",
-    "@hono/vite-dev-server": "^0.18.2",
     "vite": "^6.1.1",
+    "vite-plugin-ssr-hot-reload": "^0.2.2",
     "wrangler": "^4.4.0"
   }
 }

--- a/templates/cloudflare-workers+vite/public/static/style.css
+++ b/templates/cloudflare-workers+vite/public/static/style.css
@@ -1,0 +1,3 @@
+h1 {
+  font-family: Arial, Helvetica, sans-serif;
+}

--- a/templates/cloudflare-workers+vite/src/index.tsx
+++ b/templates/cloudflare-workers+vite/src/index.tsx
@@ -1,0 +1,12 @@
+import { Hono } from 'hono'
+import { renderer } from './renderer'
+
+const app = new Hono()
+
+app.use(renderer)
+
+app.get('/', (c) => {
+  return c.render(<h1>Hello!</h1>)
+})
+
+export default app

--- a/templates/cloudflare-workers+vite/src/renderer.tsx
+++ b/templates/cloudflare-workers+vite/src/renderer.tsx
@@ -1,0 +1,12 @@
+import { jsxRenderer } from 'hono/jsx-renderer'
+
+export const renderer = jsxRenderer(({ children }) => {
+  return (
+    <html>
+      <head>
+        <link href="/static/style.css" rel="stylesheet" />
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+})

--- a/templates/cloudflare-workers+vite/tsconfig.json
+++ b/templates/cloudflare-workers+vite/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": [
+      "ESNext"
+    ],
+    "types": [
+      "@cloudflare/workers-types/2023-07-01",
+      "vite/client"
+    ],
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  },
+}

--- a/templates/cloudflare-workers+vite/vite.config.ts
+++ b/templates/cloudflare-workers+vite/vite.config.ts
@@ -1,0 +1,7 @@
+import { cloudflare } from '@cloudflare/vite-plugin'
+import { defineConfig } from 'vite'
+import ssrHotReload from 'vite-plugin-ssr-hot-reload'
+
+export default defineConfig({
+  plugins: [ssrHotReload(), cloudflare()]
+})

--- a/templates/cloudflare-workers+vite/wrangler.jsonc
+++ b/templates/cloudflare-workers+vite/wrangler.jsonc
@@ -1,0 +1,34 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "%%PROJECT_NAME%%",
+  "compatibility_date": "2024-04-01",
+  "main": "./src/index.tsx",
+  "assets": {
+    "directory": "./public"
+  }
+  // "vars": {
+  //   "MY_VAR": "my-variable"
+  // },
+  // "kv_namespaces": [
+  //   {
+  //     "binding": "MY_KV_NAMESPACE",
+  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  //   }
+  // ],
+  // "r2_buckets": [
+  //   {
+  //     "binding": "MY_BUCKET",
+  //     "bucket_name": "my-bucket"
+  //   }
+  // ],
+  // "d1_databases": [
+  //   {
+  //     "binding": "MY_DB",
+  //     "database_name": "my-database",
+  //     "database_id": ""
+  //   }
+  // ],
+  // "ai": {
+  //   "binding": "AI"
+  // }
+}

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250214.0",
-    "wrangler": "^3.109.2"
+    "wrangler": "^4.4.0"
   }
 }

--- a/templates/x-basic/package.json
+++ b/templates/x-basic/package.json
@@ -19,6 +19,6 @@
     "@tailwindcss/vite": "^4.0.9",
     "tailwindcss": "^4.0.9",
     "vite": "^6.1.1",
-    "wrangler": "^3.109.2"
+    "wrangler": "^4.4.0"
   }
 }


### PR DESCRIPTION
This PR introduces a new template for Cloudflare Workers who are using Vite and [@cloudflare/vite-plugin](https://github.com/cloudflare/workers-sdk/tree/main/packages/vite-plugin-cloudflare). The `@cloudflare/vite-plugin` can emulate the Cloudflare environment as the same way as Wrangler. So it's better than using `@hono/vite-dev-server` for Cloudflare Workers.

Plus, Cloudflare will recommend using Cloudflare Workers instead of Cloudflare Pages for full-stack applications since both will be unified and encourage users to use Workers. So, we plan to make the `cloudflare-pages` obsolete and use this `cloudflare-workers+vite` template instead of that.