### PR TITLE
Update cloudflare templates in order to follow wrangler v4 types migration

### DIFF
--- a/templates/cloudflare-pages/README.md
+++ b/templates/cloudflare-pages/README.md
@@ -6,3 +6,9 @@ npm run dev
 ```txt
 npm run deploy
 ```
+
+[For generating/synchronizing types based on your Worker configuration run](https://developers.cloudflare.com/workers/wrangler/commands/#types):
+
+```
+npx wrangler types
+```

--- a/templates/cloudflare-pages/README.md
+++ b/templates/cloudflare-pages/README.md
@@ -9,6 +9,13 @@ npm run deploy
 
 [For generating/synchronizing types based on your Worker configuration run](https://developers.cloudflare.com/workers/wrangler/commands/#types):
 
+```txt
+npm run cf-typegen
 ```
-npx wrangler types
+
+Pass the `CloudflareBindings` as generics when instantiation `Hono`:
+
+```ts
+// src/index.ts
+const app = new Hono<{ Bindings: CloudflareBindings }>()
 ```

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -10,7 +10,6 @@
     "hono": "^4.7.7"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250214.0",
     "@hono/vite-build": "^1.2.0",
     "@hono/vite-dev-server": "^0.18.2",
     "vite": "^6.1.1",

--- a/templates/cloudflare-pages/package.json
+++ b/templates/cloudflare-pages/package.json
@@ -4,7 +4,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "wrangler pages dev",
-    "deploy": "$npm_execpath run build && wrangler pages deploy"
+    "deploy": "$npm_execpath run build && wrangler pages deploy",
+    "cf-typegen": "wrangler types --env-interface CloudflareBindings"
   },
   "dependencies": {
     "hono": "^4.7.7"

--- a/templates/cloudflare-pages/tsconfig.json
+++ b/templates/cloudflare-pages/tsconfig.json
@@ -8,9 +8,7 @@
     "lib": [
       "ESNext"
     ],
-    "types": [
-      "vite/client"
-    ],
+    "types": ["vite/client"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   },

--- a/templates/cloudflare-pages/tsconfig.json
+++ b/templates/cloudflare-pages/tsconfig.json
@@ -9,7 +9,6 @@
       "ESNext"
     ],
     "types": [
-      "@cloudflare/workers-types/2023-07-01",
       "vite/client"
     ],
     "jsx": "react-jsx",

--- a/templates/cloudflare-workers+vite/README.md
+++ b/templates/cloudflare-workers+vite/README.md
@@ -6,3 +6,9 @@ npm run dev
 ```txt
 npm run deploy
 ```
+
+[For generating/synchronizing types based on your Worker configuration run](https://developers.cloudflare.com/workers/wrangler/commands/#types):
+
+```
+npx wrangler types
+```

--- a/templates/cloudflare-workers+vite/README.md
+++ b/templates/cloudflare-workers+vite/README.md
@@ -9,6 +9,13 @@ npm run deploy
 
 [For generating/synchronizing types based on your Worker configuration run](https://developers.cloudflare.com/workers/wrangler/commands/#types):
 
+```txt
+npm run cf-typegen
 ```
-npx wrangler types
+
+Pass the `CloudflareBindings` as generics when instantiation `Hono`:
+
+```ts
+// src/index.ts
+const app = new Hono<{ Bindings: CloudflareBindings }>()
 ```

--- a/templates/cloudflare-workers+vite/package.json
+++ b/templates/cloudflare-workers+vite/package.json
@@ -11,7 +11,6 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^0.1.15",
-    "@cloudflare/workers-types": "^4.20250214.0",
     "@hono/vite-build": "^1.5.0",
     "vite": "^6.1.1",
     "vite-plugin-ssr-hot-reload": "^0.4.1",

--- a/templates/cloudflare-workers+vite/package.json
+++ b/templates/cloudflare-workers+vite/package.json
@@ -4,7 +4,8 @@
     "dev": "vite",
     "build": "vite build && vite build --ssr",
     "preview": "$npm_execpath run build && wrangler dev dist-server/index.js",
-    "deploy": "$npm_execpath run build && wrangler deploy dist-server/index.js"
+    "deploy": "$npm_execpath run build && wrangler deploy dist-server/index.js",
+    "cf-typegen": "wrangler types --env-interface CloudflareBindings"
   },
   "dependencies": {
     "hono": "^4.7.7"

--- a/templates/cloudflare-workers+vite/tsconfig.json
+++ b/templates/cloudflare-workers+vite/tsconfig.json
@@ -8,10 +8,7 @@
     "lib": [
       "ESNext"
     ],
-    "types": [
-      "@cloudflare/workers-types/2023-07-01",
-      "vite/client"
-    ],
+    "types": ["vite/client"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   },

--- a/templates/cloudflare-workers/README.md
+++ b/templates/cloudflare-workers/README.md
@@ -6,3 +6,9 @@ npm run dev
 ```
 npm run deploy
 ```
+
+[For generating/synchronizing types based on your Worker configuration run](https://developers.cloudflare.com/workers/wrangler/commands/#types):
+
+```
+npx wrangler types
+```

--- a/templates/cloudflare-workers/README.md
+++ b/templates/cloudflare-workers/README.md
@@ -1,14 +1,21 @@
-```
+```txt
 npm install
 npm run dev
 ```
 
-```
+```txt
 npm run deploy
 ```
 
 [For generating/synchronizing types based on your Worker configuration run](https://developers.cloudflare.com/workers/wrangler/commands/#types):
 
+```txt
+npm run cf-typegen
 ```
-npx wrangler types
+
+Pass the `CloudflareBindings` as generics when instantiation `Hono`:
+
+```ts
+// src/index.ts
+const app = new Hono<{ Bindings: CloudflareBindings }>()
 ```

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -7,7 +7,6 @@
     "hono": "^4.7.7"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250214.0",
     "wrangler": "^4.4.0"
   }
 }

--- a/templates/cloudflare-workers/package.json
+++ b/templates/cloudflare-workers/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy --minify"
+    "deploy": "wrangler deploy --minify",
+    "cf-typegen": "wrangler types --env-interface CloudflareBindings"
   },
   "dependencies": {
     "hono": "^4.7.7"

--- a/templates/cloudflare-workers/tsconfig.json
+++ b/templates/cloudflare-workers/tsconfig.json
@@ -8,9 +8,6 @@
     "lib": [
       "ESNext"
     ],
-    "types": [
-      "@cloudflare/workers-types/2023-07-01"
-    ],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   },


### PR DESCRIPTION
This pull request apply recommended migration for worker types usage for `wrangler@4.x`

## In summary:
- Remove `@cloudflare/workers-types`
- Add indication to user `npx wrangler types` command in order to generate cloudflare and worker binding types 

## References
- https://developers.cloudflare.com/workers/wrangler/commands/#types
- https://developers.cloudflare.com/workers/languages/typescript/#1-uninstall-cloudflareworkers-types