### PR TITLE
add starters for google cloud run on node, deno, and bun runtimes

### DIFF
--- a/templates/google-cloud-run-bun/.dockerignore
+++ b/templates/google-cloud-run-bun/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode
+Makefile
+helm-charts
+.env
+.editorconfig
+.idea
+coverage*

--- a/templates/google-cloud-run-bun/.gitignore
+++ b/templates/google-cloud-run-bun/.gitignore
@@ -1,0 +1,9 @@
+# deps
+node_modules/
+
+# env
+.env
+.env.production
+
+# misc
+.DS_Store

--- a/templates/google-cloud-run-bun/Dockerfile
+++ b/templates/google-cloud-run-bun/Dockerfile
@@ -1,0 +1,37 @@
+# use the official Bun image
+# see all versions at https://hub.docker.com/r/oven/bun/tags
+FROM oven/bun:1 AS base
+WORKDIR /usr/src/app
+
+# install dependencies into temp directory
+# this will cache them and speed up future builds
+FROM base AS install
+RUN mkdir -p /temp/dev
+COPY package.json bun.lock /temp/dev/
+RUN cd /temp/dev && bun install --frozen-lockfile
+
+# install with --production (exclude devDependencies)
+RUN mkdir -p /temp/prod
+COPY package.json bun.lock /temp/prod/
+RUN cd /temp/prod && bun install --frozen-lockfile --production
+
+# copy node_modules from temp directory
+# then copy all (non-ignored) project files into the image
+FROM base AS prerelease
+COPY --from=install /temp/dev/node_modules node_modules
+COPY . .
+
+# [optional] tests & build
+ENV NODE_ENV=production
+RUN bun run build
+
+# copy production dependencies and source code into final image
+FROM base AS release
+COPY --from=install /temp/prod/node_modules node_modules
+COPY --from=prerelease /usr/src/app/dist/index.js .
+COPY --from=prerelease /usr/src/app/package.json .
+
+# run the app
+USER bun
+EXPOSE 8080/tcp
+ENTRYPOINT [ "bun", "run", "index.js" ]

--- a/templates/google-cloud-run-bun/README.md
+++ b/templates/google-cloud-run-bun/README.md
@@ -1,0 +1,21 @@
+To install dependencies:
+```sh
+bun install
+```
+
+To run:
+```sh
+bun run dev
+```
+
+open http://localhost:8080
+
+# Building and running the container locally
+
+1. Build the container image `docker build --pull -t my-app .`
+
+2. Run the container `docker run -d -p 8080:8080 my-app`
+
+3. Visit `localhost:8080`
+
+4. To stop the container use `docker stop <container-id>`. The container ID was presented when you ran the container, alternatively you can fetch it again using `docker ps`

--- a/templates/google-cloud-run-bun/package.json
+++ b/templates/google-cloud-run-bun/package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "dev": "bun run --hot src/index.ts",
+    "build": "bun build --entrypoints ./src/index.ts --outdir ./dist --target bun"
+  },
+  "dependencies": {
+    "hono": "^4.7.7"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/templates/google-cloud-run-bun/src/index.ts
+++ b/templates/google-cloud-run-bun/src/index.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.get('/', (c) => {
+  return c.text('Hello Hono!')
+})
+
+Bun.serve({
+  fetch: app.fetch,
+  port: 8080
+})

--- a/templates/google-cloud-run-bun/tsconfig.json
+++ b/templates/google-cloud-run-bun/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  }
+}

--- a/templates/google-cloud-run-deno/.dockerignore
+++ b/templates/google-cloud-run-deno/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode
+Makefile
+helm-charts
+.env
+.editorconfig
+.idea
+coverage*

--- a/templates/google-cloud-run-deno/.gitignore
+++ b/templates/google-cloud-run-deno/.gitignore
@@ -1,0 +1,9 @@
+# deps
+node_modules/
+
+# env
+.env
+.env.production
+
+# misc
+.DS_Store

--- a/templates/google-cloud-run-deno/Dockerfile
+++ b/templates/google-cloud-run-deno/Dockerfile
@@ -1,0 +1,11 @@
+FROM denoland/deno
+
+WORKDIR /app
+
+ADD . /app
+
+RUN deno install --entrypoint main.ts
+
+EXPOSE 8080/tcp
+
+ENTRYPOINT ["deno", "run", "--allow-net", "main.ts"]

--- a/templates/google-cloud-run-deno/README.md
+++ b/templates/google-cloud-run-deno/README.md
@@ -1,0 +1,13 @@
+```
+deno task start
+```
+
+# Building and running the container locally
+
+1. Build the container image `docker build --pull -t my-app .`
+
+2. Run the container `docker run -d -p 8080:8080 my-app`
+
+3. Visit `localhost:8080`
+
+4. To stop the container use `docker stop <container-id>`. The container ID was presented when you ran the container, alternatively you can fetch it again using `docker ps`

--- a/templates/google-cloud-run-deno/deno.json
+++ b/templates/google-cloud-run-deno/deno.json
@@ -1,0 +1,12 @@
+{
+  "imports": {
+    "hono": "jsr:@hono/hono@^4.7.7"
+  },
+  "tasks": {
+    "start": "deno run --allow-net main.ts"
+  },
+  "compilerOptions": {
+    "jsx": "precompile",
+    "jsxImportSource": "hono/jsx"
+  }
+}

--- a/templates/google-cloud-run-deno/main.ts
+++ b/templates/google-cloud-run-deno/main.ts
@@ -1,0 +1,9 @@
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.get('/', (c) => {
+  return c.text('Hello Hono!')
+})
+
+Deno.serve({ port: 8080 }, app.fetch)

--- a/templates/google-cloud-run-nodejs/.dockerignore
+++ b/templates/google-cloud-run-nodejs/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode
+Makefile
+helm-charts
+.env
+.editorconfig
+.idea
+coverage*

--- a/templates/google-cloud-run-nodejs/.gitignore
+++ b/templates/google-cloud-run-nodejs/.gitignore
@@ -1,0 +1,9 @@
+# deps
+node_modules/
+
+# env
+.env
+.env.production
+
+# misc
+.DS_Store

--- a/templates/google-cloud-run-nodejs/Dockerfile
+++ b/templates/google-cloud-run-nodejs/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-alpine AS base
+
+FROM base AS builder
+
+RUN apk add --no-cache gcompat
+WORKDIR /app
+
+# assumes using npm. requires changes for alternate package managers
+COPY package*json tsconfig.json src ./
+
+RUN npm ci && \
+    npm run build && \
+    npm prune --production
+
+FROM base AS runner
+WORKDIR /app
+
+COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/package.json /app/package.json
+
+EXPOSE 8080/tcp
+
+ENTRYPOINT ["node", "/app/dist/index.js"]

--- a/templates/google-cloud-run-nodejs/README.md
+++ b/templates/google-cloud-run-nodejs/README.md
@@ -1,0 +1,18 @@
+```
+npm install
+npm run dev
+```
+
+```
+open http://localhost:8080
+```
+
+# Building and running the container locally
+
+1. Build the container image `docker build --pull -t my-app .`
+
+2. Run the container `docker run -d -p 8080:8080 my-app`
+
+3. Visit `localhost:8080`
+
+4. To stop the container use `docker stop <container-id>`. The container ID was presented when you ran the container, alternatively you can fetch it again using `docker ps`

--- a/templates/google-cloud-run-nodejs/package.json
+++ b/templates/google-cloud-run-nodejs/package.json
@@ -1,0 +1,16 @@
+{
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.14.1",
+    "hono": "^4.7.7"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.17",
+    "tsx": "^4.7.1",
+    "typescript": "^5.8.3"
+  }
+}

--- a/templates/google-cloud-run-nodejs/src/index.ts
+++ b/templates/google-cloud-run-nodejs/src/index.ts
@@ -1,0 +1,18 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.get('/', (c) => {
+  return c.text('Hello Hono!')
+})
+
+serve(
+  {
+    fetch: app.fetch,
+    port: 8080
+  },
+  (info) => {
+    console.log(`Server is running on http://localhost:${info.port}`)
+  }
+)

--- a/templates/google-cloud-run-nodejs/tsconfig.json
+++ b/templates/google-cloud-run-nodejs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ],
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx",
+    "outDir": "./dist"
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Add starters for Google Cloud Run on nodejs, deno, and bun runtimes