### PR TITLE
make nodejs starter ready-to-use

### DIFF
--- a/templates/nodejs/package.json
+++ b/templates/nodejs/package.json
@@ -1,7 +1,9 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts"
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
   },
   "dependencies": {
     "@hono/node-server": "^1.14.1",
@@ -9,6 +11,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.17",
-    "tsx": "^4.7.1"
+    "tsx": "^4.7.1",
+    "typescript": "^5.8.3"
   }
 }

--- a/templates/nodejs/tsconfig.json
+++ b/templates/nodejs/tsconfig.json
@@ -10,5 +10,7 @@
     ],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx",
-  }
+    "outDir": "./dist"
+  },
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Fixing nodejs starter instead of adding a Google Cloud Run starter as discussed in #92