### PR TITLE
use `fire()` from `hono/service-worker` instead of `app.fire()`

### DIFF
--- a/templates/fastly/src/index.ts
+++ b/templates/fastly/src/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono/quick'
+import { fire } from 'hono/service-worker'
 
 const app = new Hono()
 
@@ -6,4 +7,4 @@ app.get('/', (c) => {
   return c.text('Hello Hono!')
 })
 
-app.fire()
+fire(app)


### PR DESCRIPTION
`app.fire()` is deprecated, so use `hono/service-worker`'s `fire()`.
https://hono.dev/docs/api/hono#fire