### PR TITLE
add vercel.json to fix no entrypoint error in vercel template

### DIFF
--- a/templates/vercel/vercel.json
+++ b/templates/vercel/vercel.json
@@ -1,0 +1,10 @@
+{
+    "builds": [
+        {
+            "src": "src/index.ts",
+            "use": "@vercel/node"
+        }
+    ],
+	"rewrites": [{ "source": "/(.*)", "destination": "/src" }]
+}
+


### PR DESCRIPTION
For the vercel template to work out of the box, it needs a "vercel.json" that tells "vercel dev" to look for the index.ts in the right folder (in this case "/src"). This fixes that