### PR TITLE
nodejs: be able to build & run with imported relative files

### DIFF
--- a/templates/nodejs/package.json
+++ b/templates/nodejs/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "tsc && tsc-alias",
     "start": "node dist/index.js"
   },
   "dependencies": {
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.17",
+    "tsc-alias": "^1.8.16",
     "tsx": "^4.7.1",
     "typescript": "^5.8.3"
   }

--- a/templates/nodejs/tsconfig.json
+++ b/templates/nodejs/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "NodeNext",
+    "module": "esnext",
+    "moduleResolution": "node10",
     "strict": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
@@ -12,5 +13,8 @@
     "jsxImportSource": "hono/jsx",
     "outDir": "./dist"
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "tsc-alias": {
+    "resolveFullPaths": true
+  }
 }


### PR DESCRIPTION
I was working on building a sample on how to build a simple Hono API for [lttle.cloud](https://lttle.cloud).

This sample is supposed to showcase to you how to setup a small CRUD Hono API that gets & updates some records in a Postgres database with Drizzle ORM.

Here my project structure was as follows:

```
󰣞 src
├──  db
│   ├──  client.ts
│   ├──  drizzle.ts
│   ├──  schema.ts
│   └──  seed.ts
└──  index.ts
```

Where:
- `queries.ts` contains methods to get & update list items
- `drizzle.ts` contains the main database client
- `schema.ts` defines the Drizzle Postgres schema
- `seed.ts` is a helper file to seed the database with lists & items

What I wanted to achieve is this:

```ts
import { getFullList } from "./db/queries"

app.get("/lists", async (c) => {
  const lists = await getFullList();

  return c.json(lists);
});
```

So for this I did 2 main things:

1. Updated `tsconfig` and set the `module` to `esnext` and the `moduleResolution` to `node10`.
2. Added [`tsc-alias`](https://www.npmjs.com/package/tsc-alias) as a dev dependency and set it up.

### [tsc-alias](https://www.npmjs.com/package/tsc-alias) setup

This is a tool you use after `tsc` has finished, so I updated `package.json` like so

```diff
-    "build": "tsc",
+    "build": "tsc && tsc-alias",
```

And it also need some extra configuration to be able to transform `import { getFullList } from "./db/queries/"` to `import { getFullList } from "./db/queries.js"` that needs to be put in `tsconfig.json`:

```diff
+  "tsc-alias": {
+    "resolveFullPaths": true
+  }
```

If you want to see my sample, here it is https://github.com/lttle-cloud/samples/tree/nodejs-hono-api/nodejs/hono-api

