### PR TITLE
chore(x-basic): bump deps

### DIFF
--- a/templates/x-basic/package.json
+++ b/templates/x-basic/package.json
@@ -10,15 +10,15 @@
   "private": true,
   "dependencies": {
     "hono": "^4.12.14",
-    "honox": "^0.1.55"
+    "honox": "0.1.55"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250214.0",
-    "@hono/vite-build": "^1.3.0",
-    "@hono/vite-dev-server": "^0.18.2",
-    "@tailwindcss/vite": "^4.0.9",
-    "tailwindcss": "^4.0.9",
-    "vite": "^6.3.5",
-    "wrangler": "^4.4.0"
+    "@cloudflare/workers-types": "^4.20260420.1",
+    "@hono/vite-build": "^1.11.1",
+    "@hono/vite-dev-server": "^0.25.1",
+    "@tailwindcss/vite": "^4.2.2",
+    "tailwindcss": "^4.2.2",
+    "vite": "^8.0.9",
+    "wrangler": "^4.83.0"
   }
 }


### PR DESCRIPTION
This pull request is primarily aimed at upgrading Vite's major version, as it is currently outdated.
At least in `dev` and `preview`, I have confirmed that the counter works.

Also, I think the honox version should have been pinned, so I've corrected that as well.
- #113
