### PR TITLE
fix(cloudflare-pages): update broken adapter import

### DIFF
--- a/templates/cloudflare-pages/vite.config.ts
+++ b/templates/cloudflare-pages/vite.config.ts
@@ -1,6 +1,6 @@
 import build from '@hono/vite-build/cloudflare-pages'
 import devServer from '@hono/vite-dev-server'
-import adapter from '@hono/vite-dev-server/cloudflare'
+import adapter from '@hono/vite-dev-server/adapter/cloudflare'
 import { defineConfig } from 'vite'
 
 export default defineConfig({


### PR DESCRIPTION
Currently the adapter import in the Pages template is `@hono/vite-dev-server/cloudflare`, this is outdated and has been changes in https://github.com/honojs/vite-plugins/pull/351 (see https://github.com/honojs/vite-plugins/pull/351/changes#r3110406255).

This PR updates the import path to the correct `@hono/vite-dev-server/adapter/cloudflare` instead.