### PR TITLE
bump `@hono/node-server`

### DIFF
--- a/templates/nodejs/package.json
+++ b/templates/nodejs/package.json
@@ -6,7 +6,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.14",
+    "@hono/node-server": "^2.0.0",
     "hono": "^4.12.14"
   },
   "devDependencies": {


### PR DESCRIPTION
## Overview

https://github.com/honojs/node-server/releases/tag/v2.0.0

Hono Node.js adapter v2 has been released. The template has also been updated to use v2.
