### PR TITLE
chore(nextjs): bump next and eslint-config-next to v16.2.4

### DIFF
--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "hono": "^4.12.15",
-    "next": "15.5.2",
+    "next": "^16.2.4",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },
@@ -18,7 +18,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.5.2",
+    "eslint-config-next": "^16.2.4",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
Upgrades the Next.js template dependencies to the latest stable release.

  ## Changes
  - `next`: `15.5.2` → `^16.2.4`
  - `eslint-config-next`: `15.5.2` → `^16.2.4`