### PR TITLE
Add rootDir to tsconfig.json

### DIFF
--- a/templates/nodejs/tsconfig.json
+++ b/templates/nodejs/tsconfig.json
@@ -10,6 +10,7 @@
     ],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx",
+    "rootDir": "./src",
     "outDir": "./dist"
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
Fixed this issue:
The common source directory of 'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.
  Visit https://aka.ms/ts6 for migration information.